### PR TITLE
Allow to use the MSVC 10.0 compiler from Windows SDK 7.1

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -28,6 +28,7 @@ class Config(object):
     else:
         CONDA_NPY = int(CONDA_NPY.replace('.', '')) or None
     CONDA_R = os.getenv("CONDA_R", "3.2.2")
+    CONDA_MSVC_OVERRIDE = os.getenv('CONDA_MSVC_OVERRIDE')
 
     @property
     def PY3K(self):

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -66,6 +66,16 @@ def msvc_env_cmd(override=None):
         msvc_env_lines.append('set DISTUTILS_USE_SDK=1')
         msvc_env_lines.append('set MSSdk=1')
 
+    if version == '10.0-SDK':
+        # Special override to use the MSVC 2010 compiler (10.0) from Microsoft SDK 7.1
+        setenv = os.path.join(os.environ['ProgramFiles'], 'Microsoft SDKs', 'Windows', 'v7.1',
+            'Bin', 'SetEnv.Cmd')
+        if not isfile(setenv):
+            print("Warning: Couldn't find Visual Studio: %r" % setenv)
+            return ''
+        msvc_env_lines.append('call "%s" %s' % (setenv, '/x86' if cc.bits == 32 else '/x64'))
+        return '\n'.join(msvc_env_lines)
+
     vcvarsall = os.path.join(program_files,
                              r'Microsoft Visual Studio {version}'.format(version=version),
                              'VC', 'vcvarsall.bat')
@@ -125,7 +135,7 @@ def build(m, bld_bat):
         with open(bld_bat) as fi:
             data = fi.read()
         with open(join(src_dir, 'bld.bat'), 'w') as fo:
-            fo.write(msvc_env_cmd(override=m.get_value('build/msvc_compiler', None)))
+            fo.write(msvc_env_cmd(override=m.get_value('build/msvc_compiler', config.CONDA_MSVC_OVERRIDE)))
             fo.write('\n')
             # more debuggable with echo on
             fo.write('@echo on\n')


### PR DESCRIPTION
Also allow to specify MSVC override via environment variable (CONDA_MSVC_OVERRIDE), but the specification in meta.yaml (build/msvc_compiler) still gets preference.

This is useful for Python stacks based on this alternative compiler, and also to not pollute all recipes with the msvc_compiler specification.
